### PR TITLE
added "phase transition properties"  to pyrrhotite in mines16 data file

### DIFF
--- a/Resources/databases/mines16-thermofun.json
+++ b/Resources/databases/mines16-thermofun.json
@@ -53794,35 +53794,35 @@
               "a8",
               "a9",
               "a10"
-            ],
-            "m_phase_trans_props": {
-              "values": [
-                411.00000610352,
-                0,
-                0,
-                0,
-                0
-              ],
-              "units": [
-                "K",
-                "J/(mol*K)",
-                "J/mol",
-                "J/bar",
-                "K/bar"
-              ],
-              "names": [
-                "Temperature",
-                "dS",
-                "dH",
-                "dV",
-                "dT/dP"
-              ]
-            }
+            ]
           }
         },
         {
           "method": {
             "0": "cp_ft_equation"
+          },
+          "m_phase_trans_props": {
+            "values": [
+              411.00000610352,
+              0,
+              0,
+              0,
+              0
+            ],
+            "units": [
+              "K",
+              "J/(mol*K)",
+              "J/mol",
+              "J/bar",
+              "K/bar"
+            ],
+            "names": [
+              "Temperature",
+              "dS",
+              "dH",
+              "dV",
+              "dT/dP"
+            ]
           },
           "limitsTP": {
             "range": true,
@@ -53868,35 +53868,35 @@
               "a8",
               "a9",
               "a10"
-            ],
-            "m_phase_trans_props": {
-              "values": [
-                598.00000610352,
-                0,
-                0,
-                0,
-                0
-              ],
-              "units": [
-                "K",
-                "J/(mol*K)",
-                "J/mol",
-                "J/bar",
-                "K/bar"
-              ],
-              "names": [
-                "Temperature",
-                "dS",
-                "dH",
-                "dV",
-                "dT/dP"
-              ]
-            }
+            ]
           }
         },
         {
           "method": {
             "0": "cp_ft_equation"
+          },
+          "m_phase_trans_props": {
+            "values": [
+              598.00000610352,
+              0,
+              0,
+              0,
+              0
+            ],
+            "units": [
+              "K",
+              "J/(mol*K)",
+              "J/mol",
+              "J/bar",
+              "K/bar"
+            ],
+            "names": [
+              "Temperature",
+              "dS",
+              "dH",
+              "dV",
+              "dT/dP"
+            ]
           },
           "limitsTP": {
             "range": true,

--- a/Resources/databases/mines16-thermofun.json
+++ b/Resources/databases/mines16-thermofun.json
@@ -53794,7 +53794,30 @@
               "a8",
               "a9",
               "a10"
-            ]
+            ],
+            "m_phase_trans_props": {
+              "values": [
+                411.00000610352,
+                0,
+                0,
+                0,
+                0
+              ],
+              "units": [
+                "K",
+                "J/(mol*K)",
+                "J/mol",
+                "J/bar",
+                "K/bar"
+              ],
+              "names": [
+                "Temperature",
+                "dS",
+                "dH",
+                "dV",
+                "dT/dP"
+              ]
+            }
           }
         },
         {
@@ -53845,7 +53868,30 @@
               "a8",
               "a9",
               "a10"
-            ]
+            ],
+            "m_phase_trans_props": {
+              "values": [
+                598.00000610352,
+                0,
+                0,
+                0,
+                0
+              ],
+              "units": [
+                "K",
+                "J/(mol*K)",
+                "J/mol",
+                "J/bar",
+                "K/bar"
+              ],
+              "names": [
+                "Temperature",
+                "dS",
+                "dH",
+                "dV",
+                "dT/dP"
+              ]
+            }
           }
         },
         {


### PR DESCRIPTION
I added the "phase transition properties" (`m_phase_trans_props`) to the pyrrhotite entry in the mines16 data file. It seems that the pyrrhotite entry is the only one requiring correction. In this case—and in many cases in other data files—temperature is the only property tabulated, so the info stored in `m_phase_trans_props` is redundant wrt what is already stored in the entry. However, both ThermoFun and Reaktoro throw errors (see screenshot for ThermoFun attached) when trying to calculate thermo. properties for pyrrhotite at temperatures above its phase transitions, so it seems this redundant info is still required. In the future, would it be possible to take the temperature from `limitsTP` when `m_phase_trans_props` is not specified? This would reduce redundant info in the data file in the case that only phase transition temperature would be included in `m_phase_trans_props` (i.e., dS, dH, dV, dT/dP of transition are unknown/zero). 
![Screen Shot 2021-02-25 at 10 03 17 PM](https://user-images.githubusercontent.com/44422832/109249218-45df9a80-77b5-11eb-8c02-c573055b3206.png)
