### PR TITLE
Add GitHub Actions to build and test ThermoFun (Linux/macOS/Windows) 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,76 @@
+name: linux
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+  schedule:
+    - cron: "0 5 * * 1"  # runs at 05:00 UTC on Mondays
+
+jobs:
+  build:
+    name: ${{ matrix.config }} build on ${{ matrix.os }} (Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      max-parallel: 4
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: [3.9]
+        config: ["Release"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Timestamp  # Idea from https://tinyurl.com/47wz7vpv
+        id: timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=now::${current_date}")
+
+      - name: Configuring Cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /home/runner/.cache
+            /home/runner/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-${{ matrix.config }}-${{ runner.python-version }}-${{ github.ref }}-ccache-${ { steps.timestamp.outputs.now } }
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.config }}-${{ runner.python-version }}-${{ github.ref }}-ccache-
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          channel-priority: true
+          use-only-tar-bz2: true  # IMPORTANT: This needs to be set true for caching of miniconda packages to work properly!
+
+      - name: Configuring Conda Environment
+        shell: bash -l {0}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          conda config --set always_yes yes --set changeps1 no
+          conda config --add channels conda-forge
+          conda install conda-devenv=2
+          conda devenv
+
+      - name: Building, Testing & Installing ThermoFun
+        shell: bash -l {0}
+        run: |
+          source activate thermofun
+          ccache -s
+          ccache -z
+          mkdir .build && cd .build
+          cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+          ninja
+          ninja install
+          python -c "import thermofun"
+          ccache -s

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,0 +1,76 @@
+name: osx
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+  schedule:
+    - cron: "0 5 * * 1"  # runs at 05:00 UTC on Mondays
+
+jobs:
+  build:
+    name: ${{ matrix.config }} build on ${{ matrix.os }} (Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      max-parallel: 4
+      matrix:
+        os: ["macos-latest"]
+        python-version: [3.9]
+        config: ["Release"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Timestamp  # Idea from https://tinyurl.com/47wz7vpv
+        id: timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=now::${current_date}")
+
+      - name: Configuring Cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /Users/runner/Library/Caches/ccache
+            /Users/runner/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-${{ matrix.config }}-${{ runner.python-version }}-${{ github.ref }}-ccache-${ { steps.timestamp.outputs.now } }
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.config }}-${{ runner.python-version }}-${{ github.ref }}-ccache-
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          channel-priority: true
+          use-only-tar-bz2: true  # IMPORTANT: This needs to be set true for caching of miniconda packages to work properly!
+
+      - name: Configuring Conda Environment
+        shell: bash -l {0}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          conda config --set always_yes yes --set changeps1 no
+          conda config --add channels conda-forge
+          conda install conda-devenv=2
+          conda devenv
+
+      - name: Building, Testing & Installing ThermoFun
+        shell: bash -l {0}
+        run: |
+          source activate thermofun
+          ccache -s
+          ccache -z
+          mkdir .build && cd .build
+          cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+          ninja
+          ninja install
+          python -c "import thermofun"
+          ccache -s

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Building, Testing & Installing ThermoFun
         shell: cmd
+        env:
+          PYTHONPATH: C:\Miniconda\envs\thermofun\Library\Lib\site-packages
         run: |
           call conda activate thermofun || goto :eof
           clcache -s || goto :eof

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,77 @@
+name: windows
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+  schedule:
+    - cron: "0 5 * * 1"  # runs at 05:00 UTC on Mondays
+
+jobs:
+  build:
+    name: ${{ matrix.config }} build on ${{ matrix.os }} (Python ${{ matrix.python-version }})
+    runs-on: windows-2019
+
+    strategy:
+      fail-fast: true
+      max-parallel: 4
+      matrix:
+        os: ["windows-2019"]
+        python-version: [3.9]
+        config: ["Release"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Timestamp  # Idea from https://tinyurl.com/47wz7vpv
+        id: timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=now::${current_date}")
+
+      - name: Configuring Cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            C:\Users\runneradmin\clcache
+            C:\Users\runneradmin\conda_pkgs_dir
+          key:
+            ${{ runner.os }}-${{ matrix.config }}-${{ runner.python-version }}-${{ github.ref }}-clcache-${ { steps.timestamp.outputs.now } }
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.config }}-${{ runner.python-version }}-${{ github.ref }}-clcache-
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-activate-base: false
+          allow-softlinks: true
+          activate-environment: ''
+          channels: conda-forge
+          channel-priority: true
+          use-only-tar-bz2: true  # IMPORTANT: This needs to be set true for caching of miniconda packages to work properly!
+
+      - name: Configuring Conda Environment
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          conda config --set always_yes yes --set changeps1 no
+          conda config --add channels conda-forge
+          conda install conda-devenv=2
+          conda devenv
+
+      - name: Building, Testing & Installing ThermoFun
+        shell: cmd
+        run: |
+          call conda activate thermofun || goto :eof
+          clcache -s || goto :eof
+          clcache -z || goto :eof
+          mkdir .build && cd .build || goto :eof
+          cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ matrix.config }} || goto :eof
+          ninja || goto :eof
+          ninja install || goto :eof
+          python -c "import thermofun" || goto :eof
+          clcache -s || goto :eof

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -8,6 +8,7 @@ dependencies:
   - gxx_linux-64=9.4.0  # [linux]
   - cmake>=3.13
   - ninja
+  - clcache  # [win]
   - ccache  # [unix]
   - pybind11
   - nlohmann_json

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -5,17 +5,19 @@ name: thermofun
 dependencies:
   - setuptools=59.7.0
   - pip
-  - gxx_linux-64=9.4.0  # [linux]
+  - gxx_linux-64  # [linux]
   - cmake>=3.13
   - ninja
   - clcache  # [win]
   - ccache  # [unix]
+  - clangxx_osx-64  # [osx]
   - pybind11
   - nlohmann_json
   - spdlog=1.10.0
   - chemicalfun=0.1.4
   - python={{ python_version }}
   - pytest
+  - vs2019_win-64  # [win]
   - pip:
     - mkdocs
     - mkdocs-material


### PR DESCRIPTION
This PR will enable GitHub actions that will build and test ThermoFun on each push and pull request. These tasks will be executed for Linux, macOS and Windows builds. GitHub Actions has become a more common solution for CI. 

This PR, once merged, leaves Travis and Azure builds as redundant (could be removed).