### PR TITLE
Improvements in `ThermoFunConfig.cmake.in` 

### DIFF
--- a/cmake/modules/ThermoFunConfig.cmake.in
+++ b/cmake/modules/ThermoFunConfig.cmake.in
@@ -9,5 +9,9 @@ if(NOT TARGET ThermoFun::ThermoFun)
     include("@PACKAGE_THERMOFUN_INSTALL_CONFIGDIR@/ThermoFunTargets.cmake")
 endif()
 
+# Find all dependencies below.
+find_package(ChemicalFun REQUIRED)
+find_package(spdlog CONFIG REQUIRED)
+
 # Recommended check at the end of a cmake config file.
 check_required_components(ThermoFun)

--- a/cmake/modules/ThermoFunFindDeps.cmake
+++ b/cmake/modules/ThermoFunFindDeps.cmake
@@ -17,6 +17,8 @@ endif()
 find_package(ChemicalFun REQUIRED)
 if(NOT ChemicalFun_FOUND)
     message(FATAL_ERROR "ChemicalFun library not found")
+else()
+    message(STATUS "Found ChemicalFun: ${ChemicalFun_DIR} (found version \"${ChemicalFun_VERSION}\")")
 endif()
 
 if(USE_SPDLOG_PRECOMPILED)


### PR DESCRIPTION
This PR adds `find_package` calls for the libraries that ThermoFun depends in the `ThermoFunConfig.cmake.in` module:

~~~cmake
find_package(ChemicalFun REQUIRED)
find_package(spdlog CONFIG REQUIRED)
~~~

This is needed so that codes depending on ThermoFun will be able to automatically find its dependencies too.